### PR TITLE
support Static method

### DIFF
--- a/FSM/GraphViz.php
+++ b/FSM/GraphViz.php
@@ -294,7 +294,9 @@ class FSM_GraphViz extends FSM
         }
 
         if (!is_array($callback)) {
-            $reflector = new ReflectionFunction($callback);
+            strstr($callback, '::')
+                ? $reflector = new ReflectionMethod($callback)
+                : $reflector = new ReflectionFunction($callback);
         } else {
             $reflector = new ReflectionMethod($callback[0], $callback[1]);
         }


### PR DESCRIPTION
throw exception "class not found" when use static method.

```php
class Test 
{
    public static function func1() {}
}

$action = '\Test::func1';
```